### PR TITLE
load flags without async await when possible

### DIFF
--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomInstance.cs
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomInstance.cs
@@ -41,14 +41,6 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
             }
         }
 
-        private void OnDrawGizmos()
-        {
-            if (_room == null)
-            {
-                return;
-            }
-            Gizmos.color = Color.yellow;
-            Gizmos.DrawWireSphere(transform.position, _room.RoomLoadRadius);
-        }
+
     }
 }

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoader.cs
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoader.cs
@@ -151,13 +151,13 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
         private async UniTask ForceLoadRoomInterior(RoomLoadHandle handle)
         {
             await handle.LoadScene();
-            handle.Room.HandleRoomExteriorLoaded();
+            handle.Room.HandleRoomInteriorLoaded();
             OnRoomExteriorLoaded?.Invoke(handle.Room);
         }
         private async UniTask ForceLoadRoomExterior(RoomLoadHandle handle)
         {
             await handle.LoadScene();
-            handle.Room.HandleRoomInteriorLoaded();
+            handle.Room.HandleRoomExteriorLoaded();
             OnRoomInteriorLoaded?.Invoke(handle.Room);
         }
         

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoader.cs
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoader.cs
@@ -152,13 +152,13 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
         {
             await handle.LoadScene();
             handle.Room.HandleRoomInteriorLoaded();
-            OnRoomExteriorLoaded?.Invoke(handle.Room);
+            OnRoomInteriorLoaded?.Invoke(handle.Room);
         }
         private async UniTask ForceLoadRoomExterior(RoomLoadHandle handle)
         {
             await handle.LoadScene();
             handle.Room.HandleRoomExteriorLoaded();
-            OnRoomInteriorLoaded?.Invoke(handle.Room);
+            OnRoomExteriorLoaded?.Invoke(handle.Room);
         }
         
         public RoomLoadHandle AddExteriorLoadRequest(RoomLoadRequestData loadRequest, RoomFlag flags)

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/package.json
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.studio23.ss2.addressablechunkloadersystem",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "displayName": "Addressable Chunk Loader System",
     "description": "Addressable Chunk/Room Loader System using addressables we made for SS2",
     "unity": "2022.3",


### PR DESCRIPTION
Previous code was triggering an async wait everytime a room loading flag was set which was unnecessary. 
Small bugfix with interior rooms not being loaded.

@coderabbitai review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced room loading logic for improved performance and reliability.

- **Bug Fixes**
  - Addressed room loading order issue to ensure accurate display and functionality.

- **Style**
  - Removed visual gizmos from room instances for a cleaner gameplay experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->