### PR TITLE
Remove assetreference<Sceneasset> due to build errors + minor fixes

### DIFF
--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomInstance.cs
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomInstance.cs
@@ -27,6 +27,8 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
             {
                 return;
             }
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawWireSphere(_room.WorldPosition, _room.RoomLoadRadius); 
             Gizmos.color = Color.blue;
             Gizmos.DrawSphere(_room.WorldPosition, .125f);
             Gizmos.DrawRay(_room.WorldPosition, Vector3.up* 9);

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoadHandle.cs
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoadHandle.cs
@@ -135,6 +135,8 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
                     //we need to fetch the scene name from the asset ref
                     //and unload it manually
                     //But this situation shouldn't be ocurring in a build to begin with.
+                    //We need to do this in editor only for the initial scene
+                    //so doesn't matter perf wise,
                     var locations = await Addressables.LoadResourceLocationsAsync(_scene);
                     var sceneID = locations.First().InternalId;
                     await SceneManager.UnloadSceneAsync(sceneID);
@@ -179,6 +181,7 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
         public override string ToString()
         {
             var s = $"{Room.name}{(_isInterior ? "interior" : "exterior")} {_flags} UsesAddressable: {UsesAddressable} {(LoadHandle.IsDone ? "is loaded" : $"loading ")} unload timer:{UnloadTimer.Timer}/{UnloadTimer.MaxValue} ";
+            var s = $"{Room.name}{(_isInterior ? "interior" : "exterior")} FLAGS {_flags} UsesAddressable: {UsesAddressable} {(LoadHandle.IsDone ? "is loaded" : $"loading ")} unload timer:{UnloadTimer.Timer}/{UnloadTimer.MaxValue} ";
 
             return s;
         }

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoader.cs
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Core/RoomLoader.cs
@@ -68,7 +68,7 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
                 {
                     if (handle.UnloadTimer.tryCompleteTimer(Time.deltaTime))
                     {
-                        Debug.Log($"{room} unload Try Unloading");
+                        Debug.Log($"{room} unload schedule");
 
                         _roomsToUnloadListCache.Add(room);
                     }
@@ -128,6 +128,8 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
             if (_roomExteriorLoadHandles.TryGetValue(requestData.RoomToLoad, out handle))
             {
                 //#TODO in the case of an existing handle, we may want to update priority
+                // Debug.Log(requestData.RoomToLoad + " get handle " + handle);
+
                 handle.AddFlag(flags);
             }
             else
@@ -140,6 +142,9 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
                     requestData.ActivateOnLoad, 
                     requestData.Priority
                 );
+                
+                // Debug.Log(requestData.RoomToLoad + " start handle ");
+
                 _roomExteriorLoadHandles.Add(requestData.RoomToLoad, handle);
                 ForceLoadRoomExterior(handle);
             }
@@ -151,11 +156,22 @@ namespace Studio23.SS2.AddressableChunkLoaderSystem.Core
         private async UniTask ForceLoadRoomInterior(RoomLoadHandle handle)
         {
             await handle.LoadScene();
+            // while (handle.UsesAddressable && !handle.LoadHandle.IsDone)
+            // {
+            //     await UniTask.Yield();
+            // }
+            
+            
             handle.Room.HandleRoomInteriorLoaded();
             OnRoomInteriorLoaded?.Invoke(handle.Room);
         }
         private async UniTask ForceLoadRoomExterior(RoomLoadHandle handle)
         {
+            // while (handle.UsesAddressable && !handle.LoadHandle.IsDone)
+            // {
+            //     await UniTask.Yield();
+            //     Debug.Log(handle.Room + " loading " + handle.LoadHandle.PercentComplete);
+            // }
             await handle.LoadScene();
             handle.Room.HandleRoomExteriorLoaded();
             OnRoomExteriorLoaded?.Invoke(handle.Room);

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Data/RoomData.cs
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/Data/RoomData.cs
@@ -4,17 +4,23 @@ using NaughtyAttributes;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.Serialization;
 
 namespace Studio23.SS2.AddressableChunkLoaderSystem.Data
 {
     [CreateAssetMenu(menuName = "Studio-23/RoomLoadingSystem/RoomData", fileName = "RoomData")]
     public class RoomData:ScriptableObject
     {
-        public AssetReferenceT<SceneAsset> InteriorScene;
-        public AssetReferenceT<SceneAsset> ExteriorScene;
+        [FormerlySerializedAs("InteriorScene1")] 
+        public AssetReference InteriorScene;
+        [FormerlySerializedAs("ExteriorScene2")] 
+        public AssetReference ExteriorScene;
+            
+
         public Vector3 WorldPosition;
         public float RoomLoadRadius = 4;
         public float MinUnloadTimeout = 10;
+        
         [ShowNativeProperty] public FloorData Floor { get; internal set; }
 
         [SerializeField] List<RoomData> _alwaysLoadRooms;

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/com.studio23.ss2.addressablechunkloadersystem.asmdef
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Runtime/com.studio23.ss2.addressablechunkloadersystem.asmdef
@@ -6,9 +6,8 @@
         "GUID:46158582eccf34a44b1babd93ec99d06",
         "GUID:776d03a35f1b52c4a9aed9f56d7b4229",
         "GUID:75469ad4d38634e559750d17036d5f7c",
-        "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:9e24947de15b9834991c9d8411ea37cf",
-        "GUID:b85a516fe86321c44bbce182e5e09470",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:593a5b492d29ac6448b1ebf7f035ef33",
         "GUID:84651a3751eca9349aac36a66bba901b"
     ],

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Input.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Input.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 48426ee9f2de9dc469637b06c14834df
+guid: e8c60898db6906f439bf67f42e27b159
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Input/RoomLoadingSysteSampleInputMap.inputactions.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Input/RoomLoadingSysteSampleInputMap.inputactions.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ce692e27ac0ab8a4e991e7ed696a9bd6
+guid: 5ca43b7e782761a4fb3cb9a3bb34dc6b
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Input/Test Character Input.inputactions.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Input/Test Character Input.inputactions.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 81a5ba61f5bf5574e820a0090bb4926c
+guid: e0ce5153e5b566444ad3424ef6aec43e
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 78be126a7dabfc645aed4ce21be99c39
+guid: 9f96cdb92c7d67e42b5f41d7742f0838
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Door mat.mat.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Door mat.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7eacaf933f9583f4a8d7646eca82eeaa
+guid: ee22d08f3c109e44fb7e30cac3b0356e
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Ground.mat.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Ground.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2d20d95fa224c147aea41c2ea797452
+guid: 9ee4f93e1182fbb4fa5877e5ffd53053
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Interactable door mat.mat.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Interactable door mat.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6273d7221595c2f4b9ce534c4a91675d
+guid: 7cd2cd60ea26e774aadf994607413c8c
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Metal slab.mat.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Metal slab.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b8cd37adc6703b84e9c51dfc9ea335e0
+guid: 694dfc132f5122249a28adf4c7dc4c40
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/New Lighting Settings.lighting.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/New Lighting Settings.lighting.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6974e6d6c622abe49b676d5c56e23429
+guid: 5e943b2c3f8aa664cafc67b48aa2b919
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 4890085278179872738

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/PlayerMaterial.mat.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/PlayerMaterial.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: af2035c3769625b408a0f660523d7405
+guid: 2b4fa330f48fd094aa6391be2404baea
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Room Walls.mat.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Room Walls.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 92d04a33f9608f24fa90f83d597519e4
+guid: a2973829cf3f6714c8904dd5ea9ca733
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Wall mat.mat.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Materials/Wall mat.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 455e583d9ca599847ad86081b7519f2c
+guid: da37410d823184445b49f0db3e769c7d
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6f99a3fbd00df8a40a8d411156cd5fa1
+guid: e8e514fcc793b4347b64ecea06d76eb8
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Camera.prefab
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Camera.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 8009013523111349477}
   - component: {fileID: 8230425064145511684}
   - component: {fileID: 8710188529685350540}
+  - component: {fileID: 7184497979370153971}
   m_Layer: 0
   m_Name: Camera
   m_TagString: Untagged
@@ -240,3 +241,47 @@ MonoBehaviour:
   blendDistance: 0
   weight: 1
   sharedProfile: {fileID: 11400000, guid: 3af91f3e268c2dc47ab7e71781463080, type: 2}
+--- !u!114 &7184497979370153971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7478305623153292843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Camera.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Camera.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2a2a55e9778d19f4da79ae637e08175c
+guid: c6d07d9147fc0d1448c7dd26e251b5b5
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Cube.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Cube.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 588719a424e9d2242ba206460f4e30ce
+guid: 919910f1e8609eb419316161b1f4aaae
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/CubeModel.fbx.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/CubeModel.fbx.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 83b5416a0a5604e4fa660444bc63c406
+guid: a7e578151a6c4e047a63417d3f2d9c8a
 ModelImporter:
   serializedVersion: 22200
   internalIDToNameTable: []

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Door.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/Door.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 905c91e915749644986b955fc80dbd69
+guid: 4cc8308a52ad8534ea249f3adc308ee9
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/First Person Camera.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/First Person Camera.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: df04b918affa7b640af161ccc11fba94
+guid: 53b95642029754b49aad943f6d6efdd5
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/FullObjectiveView.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/FullObjectiveView.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ec131cd661e0b5e4199c170aa8de1932
+guid: ec4fe3a8966aff04f9a3d9a7bd596ad7
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/HintView.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/HintView.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6502e46cdf2467945ab6a2351f5b8984
+guid: 03173c60574c7b24fa877608e83965b6
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/ObjectiveTaskView.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/ObjectiveTaskView.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fc2761e15ccb3504e861d85d97e2cb58
+guid: f6313b528ad40cc42a0cefc9830d2909
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/RoomLoadManager.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/RoomLoadManager.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eaafa4cf0f94062469cb8b27eb3d9886
+guid: befb16ce7d041a648888ff09a255ca2b
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/SelectedObjectiveView.prefab.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Prefabs/SelectedObjectiveView.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 66915a249b0e8cc4dac3da340856f8b2
+guid: 818630517a5b53d429f443830225285d
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scenes.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scenes.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 64e1b15f8f7ddc347aa1118c35b29f18
+guid: 548038fb18b48b24fbc260c44a10fbda
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: b6b5accb75394b50b99131785972224d
+guid: 630cf1caa9ff0b64fb2c552200ca12e2
 timeCreated: 1700208416

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/AlwaysLoadRoomTrigger.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/AlwaysLoadRoomTrigger.cs.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: d9e7143c13414446803f6d89c7f9108e
+guid: 6bd57e957a3a8f948ac910d38da2d4c2
 timeCreated: 1702371918

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/Door.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/Door.cs.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: cd5015dc4ece431890bca2542e769485
+guid: c7df771af74830a4d84efd0eb81aa2cf
 timeCreated: 1702361304

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/PlayerDetector.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/PlayerDetector.cs.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: dd609e117146457a9dc6068092b3884b
+guid: d671cbd86ac23ab4fb208ccffe1324ac
 timeCreated: 1702540455

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/RoomEventTester.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/RoomEventTester.cs.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: 315a3b26492945ca81020251ce9b8ea3
+guid: af3460838f901af41bc62bc42c254276
 timeCreated: 1702367615

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/RoomLoadExample.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/RoomLoadExample.cs.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: 17c530a8581b4d2e91f7af5ec1abd7f3
+guid: 0d576ebb2fe35b84099b9cfcad8aac96
 timeCreated: 1702459353

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/RoomPlayerSpawner.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/RoomPlayerSpawner.cs.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: 8e9ec3b84ec74479b14554587d5e62a7
+guid: d794446cd2804f744b3b7f75404c001b
 timeCreated: 1702532936

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/TestCharacterController.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/TestCharacterController.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 92b59a85a57bf4d4d93fc33bf61cbc91
+guid: e1c4b6af7637d154aa8cf83bd6c7ebcb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/TestCharacterInputs.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/TestCharacterInputs.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d79e28b3d4b22344d877be0e35bf522c
+guid: ab9b421bf1d58894b862ff70b182fc9c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/TestPlayerManager.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/Samples/AddressableChunkLoaderSystem.Sample1/Scripts/TestPlayerManager.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 197fb4c77d70b014cbc8056c9f9656e1
+guid: 7f990615ffee33e47b549f3f3c8d0673
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/package.json
+++ b/Assets/Packages/com.studio23.ss2.addressablechunkloadersystem/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.studio23.ss2.addressablechunkloadersystem",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "displayName": "Addressable Chunk Loader System",
     "description": "Addressable Chunk/Room Loader System using addressables we made for SS2",
     "unity": "2022.3",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Visual enhancement: Rooms now display a yellow wire sphere indicating the load radius in the game world.
- **Refactor**
	- Improved scene unloading scenario handling and updated debug information for better clarity.
- **Documentation**
	- Added comments for better understanding of asynchronous loading code (currently commented out).
- **Style**
	- Renamed scene fields for consistency and clarity.
- **Chores**
	- Updated internal asset identifiers (GUIDs) for project management purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->